### PR TITLE
Enforce git worktree workflow for all new work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,3 +168,13 @@ tags: ["tag1", "tag2"]
 - **Static output** - All routes generated at build time
 - Uses **npm** (not yarn/pnpm)
 - PocketBase backend runs separately (see `backend/README.md`)
+
+## Worktree Workflow (Required)
+
+All new units of work (features, bugfixes, refactors) **must** be performed in a discrete git worktree — never directly in the main working tree.
+
+### Rules
+- Use `EnterWorktree` before beginning any implementation work
+- A `PreToolUse` hook enforces this: edits to project files outside a worktree are **denied**
+- **Exception**: `.claude/` configuration changes (hooks, settings) are allowed in the main tree
+- One worktree per unit of work — keeps changes isolated and reviewable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,3 +132,13 @@ All components must support dark mode:
 - **Build is static** - all routes generated at build time
 - Uses **npm** (not yarn/pnpm)
 - **TypeScript** enabled with strict mode
+
+## Worktree Workflow (Required)
+
+All new units of work (features, bugfixes, refactors) **must** be performed in a discrete git worktree — never directly in the main working tree.
+
+### Rules
+- Use `EnterWorktree` before beginning any implementation work
+- A `PreToolUse` hook enforces this: edits to project files outside a worktree are **denied**
+- **Exception**: `.claude/` configuration changes (hooks, settings) are allowed in the main tree
+- One worktree per unit of work — keeps changes isolated and reviewable


### PR DESCRIPTION
## Summary
- Add "Worktree Workflow (Required)" section to both `CLAUDE.md` and `AGENTS.md`
- Documents that all new units of work must use a discrete git worktree
- Complements the `PreToolUse` hook (`.claude/hooks/require-worktree.sh`) that denies edits outside a worktree, with an exception for `.claude/` config paths

## Test plan
- [ ] From the main working tree, attempt an edit to a `src/` file — should be denied by the hook
- [ ] From the main working tree, attempt an edit to `.claude/` — should be allowed (exception)
- [ ] Enter a worktree via `EnterWorktree`, attempt an edit to `src/` — should be allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)