### PR TITLE
Establish ADR practice for deployment and production decisions

### DIFF
--- a/doc/adr/0001-record-architecture-decisions.md
+++ b/doc/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,27 @@
+# ADR 0001: Record Architecture Decisions
+
+**Status**: Accepted
+
+**Date**: 2026-02-28
+
+## Context
+
+Significant architectural decisions are made during the life of the cscs.dev project, but they are currently scattered across deploy scripts, configuration files, and tribal knowledge. When a new contributor encounters the infrastructure — a GCE e2-micro VM running PocketBase via Podman Quadlet, a Netlify-hosted static frontend, a split CI/deploy pipeline — there is no single place to understand why these choices were made or what tradeoffs were considered.
+
+Without a record, future contributors must reverse-engineer rationale from code alone. Decisions that seemed obvious at the time become mysterious six months later. Alternatives that were considered and rejected get proposed again.
+
+## Decision
+
+We will use Architecture Decision Records, as described by Michael Nygard, to document significant architectural decisions in this project. ADRs will be stored in `doc/adr/` as markdown files, numbered sequentially with four-digit zero-padded identifiers (e.g., `0001-record-architecture-decisions.md`).
+
+Each ADR will contain a title, status, date, context, decision, and consequences section. The status of an ADR can be proposed, accepted, deprecated, or superseded. When an ADR is superseded, it will reference the replacement ADR.
+
+ADRs will be committed alongside the code they describe, so decisions and their rationale age together with the codebase.
+
+## Consequences
+
+- Architectural decisions become discoverable and reviewable by anyone with access to the repository.
+- The reasoning behind past decisions is preserved, preventing repeated discussions about choices that were already evaluated.
+- A lightweight template makes it easy to record new decisions without significant overhead.
+- ADRs are a social convention, not a technical enforcement — there is no mechanism that requires an ADR be written for every decision.
+- The `doc/adr/` directory will grow over time, but each file is small (1-2 pages) and the overhead is minimal.

--- a/doc/adr/0002-static-site-generation-with-astro.md
+++ b/doc/adr/0002-static-site-generation-with-astro.md
@@ -1,0 +1,28 @@
+# ADR 0002: Static Site Generation with Astro
+
+**Status**: Accepted
+
+**Date**: 2026-02-28
+
+## Context
+
+The cscs.dev website is a community hub for the College Station Computer Science group. It serves a blog, event listings, newsletter signup, and user authentication. Most of the content — blog posts, the landing page, SEO metadata — is not user-specific and does not change between requests.
+
+The team is comfortable with React for building interactive UI components. However, shipping a full React single-page application would mean sending a large JavaScript bundle to the browser for pages that are fundamentally static content.
+
+Performance and simplicity of deployment are priorities. The site should be hostable on any static file server or CDN without requiring a Node.js runtime in production.
+
+## Decision
+
+We will build the frontend using Astro 5 with `output: "static"`, producing a fully pre-rendered static site at build time. Interactive components (authentication, event RSVP, form handling) will use React 19 via Astro's islands architecture, hydrated selectively with `client:load`, `client:visible`, and `client:only="react"` directives.
+
+The Astro configuration sets `site: "https://cscs.dev"` and uses the React and Sitemap integrations. Tailwind CSS v4 is loaded through Astro's Vite plugin pipeline.
+
+## Consequences
+
+- Pages are pre-rendered to static HTML, enabling zero-latency delivery from a CDN edge with no server-side compute.
+- No Node.js server is needed in production for the frontend — the build output is plain files in `./dist/`.
+- React is available where interactivity is genuinely needed (auth flows, forms, dynamic event lists) without shipping JavaScript for static content.
+- Blog posts and pages require a rebuild to update, since all routes are generated at build time.
+- Client-side authentication cannot enforce server-side route protection — protected pages are served as static HTML with client-side auth checks.
+- The `PUBLIC_POCKETBASE_URL` environment variable is resolved at build time, not at request time.

--- a/doc/adr/0003-frontend-hosting-on-netlify.md
+++ b/doc/adr/0003-frontend-hosting-on-netlify.md
@@ -1,0 +1,27 @@
+# ADR 0003: Frontend Hosting on Netlify
+
+**Status**: Accepted
+
+**Date**: 2026-02-28
+
+## Context
+
+The frontend is a static build artifact (see [ADR 0002](0002-static-site-generation-with-astro.md)). It needs hosting that auto-deploys on push to the main branch, provides a global CDN, and handles custom domains with TLS — all without operational overhead. Budget is minimal since this is a community project.
+
+Alternatives considered included GitHub Pages, Cloudflare Pages, and Vercel. All would work for static hosting, but the team chose to move forward with Netlify due to familiarity and its built-in form handling capability.
+
+## Decision
+
+We will host the static frontend on Netlify under the project name `cscsdev`, connected directly to the GitHub repository. Netlify auto-detects the Astro framework and runs the build on every push to main. No `netlify.toml` configuration file is maintained in the repository — Netlify's auto-detection handles build commands and publish directory correctly.
+
+The custom domain `cscs.dev` is configured through Netlify's domain management. The newsletter form uses `data-netlify="true"` to leverage Netlify Forms for submission capture.
+
+## Consequences
+
+- Zero infrastructure to manage for the frontend — no servers, no containers, no CDN configuration.
+- Automatic deploy previews are available for pull requests, enabling visual review before merge.
+- SSL/TLS is handled automatically by Netlify for the custom domain.
+- A Netlify status badge in `README.md` provides instant build status visibility.
+- Netlify is an external dependency; outages or pricing changes affect site availability.
+- Deployment is not gated by CI — Netlify builds and deploys independently of the GitHub Actions workflow (see [ADR 0009](0009-ci-cd-github-actions-and-netlify.md)), so a push could fail CI checks but still deploy to production.
+- The absence of a `netlify.toml` means build configuration is not version-controlled. If Netlify's auto-detection behavior changes, the build could break without a code change.

--- a/doc/adr/0004-pocketbase-as-backend.md
+++ b/doc/adr/0004-pocketbase-as-backend.md
@@ -1,0 +1,29 @@
+# ADR 0004: PocketBase as Backend
+
+**Status**: Accepted
+
+**Date**: 2026-02-28
+
+## Context
+
+The site needs user authentication (email/password registration and login), event management (CRUD operations for community events), and RSVP functionality. These features require a persistent backend with a database, REST API, and auth system.
+
+The team is small and this is a community project. The operational cost of running a traditional API server with a separate database, ORM, migration framework, and auth library would be disproportionate to the project's scale. The expected traffic is modest — a local tech community, not a high-scale application.
+
+SQLite-backed solutions are acceptable at this traffic level and avoid the need for a separate database server.
+
+## Decision
+
+We will use PocketBase v0.34.0 as the sole backend service. PocketBase provides a built-in REST API, SQLite persistence, an admin dashboard, user authentication (email/password), collection-level access control rules, and JavaScript migration support — all in a single pre-compiled Go binary.
+
+The backend is accessed by the frontend at `https://api.cscs.dev` in production and `http://localhost:8080` in development. Schema changes are managed through the PocketBase admin UI with automigrate enabled, generating JavaScript migration files in `backend/pb_migrations/`.
+
+## Consequences
+
+- One binary, one service, zero infrastructure dependencies beyond the VM it runs on. No separate database server, no ORM, no auth framework to configure.
+- Schema changes and migrations are managed through PocketBase's admin UI, which auto-generates versioned migration files.
+- Auth, CRUD, file storage, and access control rules are included without additional packages or configuration.
+- PocketBase is a single point of failure for the backend. If the process goes down, all authenticated features are unavailable.
+- SQLite does not scale horizontally. If the community grows significantly, the database engine becomes a bottleneck.
+- Upgrading PocketBase major versions can introduce breaking changes to the API or admin interface.
+- All API access goes through PocketBase's standard REST interface, which the frontend consumes via the PocketBase JavaScript SDK.

--- a/doc/adr/0005-backend-hosting-on-gce-e2-micro.md
+++ b/doc/adr/0005-backend-hosting-on-gce-e2-micro.md
@@ -1,0 +1,28 @@
+# ADR 0005: Backend Hosting on GCE e2-micro
+
+**Status**: Accepted
+
+**Date**: 2026-02-28
+
+## Context
+
+PocketBase requires a persistent process with persistent storage — it cannot run on a serverless platform or a static hosting CDN. The backend needs to be reachable at a stable IP address for DNS to point `api.cscs.dev` at it.
+
+The team already has a Google Cloud Platform account (project `cscsdotdev`). Cost must be minimal for a community project. GCP's `e2-micro` instance type qualifies for the free tier in `us-central1`.
+
+## Decision
+
+We will host the PocketBase backend on a GCE VM named `cscs-dev-backend`, machine type `e2-micro`, running Ubuntu 24.04 LTS in zone `us-central1-a`. A regional static IP address (`cscs-backend-ip`) is reserved separately so it survives VM replacement.
+
+The VM is provisioned via `backend/deploy.sh`, which handles instance creation, firewall rules (ports 80 and 443), static IP allocation, and persistent disk attachment. A 1GB swap file is created at first boot by the startup script to prevent OOM kills during package installation on the memory-constrained instance.
+
+SSH access is configured through VM metadata with the user `jackvincenthall` and an RSA public key.
+
+## Consequences
+
+- Hosting cost is effectively free under GCP's free tier for `e2-micro` in `us-central1`.
+- The VM can be torn down (`deploy.sh down`) and recreated (`deploy.sh up`) without data loss, because the persistent disk and static IP are separate resources that survive VM deletion.
+- The `e2-micro` instance has only 1 vCPU and 1GB RAM. The swap workaround is a signal that the instance is memory-constrained. Heavy operations (large migrations, concurrent requests) may be slow.
+- There is no auto-scaling or load balancing. If the VM goes down, the backend is unavailable until manually restarted.
+- The startup script (`backend/startup.sh`) is the authoritative infrastructure definition — it configures everything from swap to container runtime to the PocketBase service.
+- Firewall rules allow inbound traffic on ports 80 and 443 from all sources (`0.0.0.0/0`) to instances tagged `https-server`.

--- a/doc/adr/0006-container-runtime-podman-with-quadlet.md
+++ b/doc/adr/0006-container-runtime-podman-with-quadlet.md
@@ -1,0 +1,26 @@
+# ADR 0006: Container Runtime — Podman with Quadlet
+
+**Status**: Accepted
+
+**Date**: 2026-02-28
+
+## Context
+
+PocketBase runs inside a container to isolate it from the host OS and make deployments reproducible. The host is an Ubuntu 24.04 VM on GCE (see [ADR 0005](0005-backend-hosting-on-gce-e2-micro.md)).
+
+Docker requires a daemon running as root, which introduces a security concern on a single-purpose VM. Podman is a daemonless, rootless-capable container runtime that is a drop-in replacement for Docker CLI commands. Quadlet is Podman's systemd integration layer, allowing containers to be managed as native systemd services.
+
+## Decision
+
+We will run PocketBase using Podman, managed by systemd via Podman Quadlet. The startup script installs Podman, writes a Kubernetes Pod YAML definition to `/etc/containers/systemd/pocketbase.yaml`, and creates a Quadlet `.kube` unit file at `/etc/containers/systemd/pocketbase.kube`. Systemd handles service startup, restart-on-failure, and dependency ordering.
+
+PocketBase listens directly on ports 80 and 443, enabled by setting `net.ipv4.ip_unprivileged_port_start=80` via sysctl. The container image is pulled from Google Artifact Registry (see [ADR 0008](0008-container-registry-google-artifact-registry.md)). PocketBase handles its own TLS certificate provisioning for the `api.cscs.dev` domain.
+
+## Consequences
+
+- No Docker daemon required. Podman runs containers without a persistent root-level process.
+- The container is managed as a systemd unit (`pocketbase.service`), benefiting from systemd's restart policies, logging (journalctl), and boot-time ordering.
+- The Kubernetes Pod YAML format means the container definition is portable and familiar to anyone who has worked with Kubernetes manifests.
+- Quadlet is a relatively new feature in the Podman ecosystem. Documentation and community examples are less mature than Docker Compose.
+- Debugging requires familiarity with both Podman and systemd tooling (`podman ps`, `systemctl status`, `journalctl`).
+- The Kubernetes YAML and Quadlet unit file are embedded as heredocs in `backend/startup.sh` and baked into the VM at creation time. Updating them requires either a new VM deployment or SSH access to modify in place.

--- a/doc/adr/0007-persistent-data-on-separate-gce-disk.md
+++ b/doc/adr/0007-persistent-data-on-separate-gce-disk.md
@@ -1,0 +1,29 @@
+# ADR 0007: Persistent Data on Separate GCE Disk
+
+**Status**: Accepted
+
+**Date**: 2026-02-28
+
+## Context
+
+PocketBase stores all data — the SQLite database, uploaded files, and migration history — on disk. If this data lived on the VM's boot disk, deleting and recreating the VM (a routine operation via `deploy.sh down` / `deploy.sh up`) would destroy all application data.
+
+The deployment model treats the VM as disposable infrastructure that can be rebuilt from the startup script at any time. Data must survive VM lifecycle events.
+
+## Decision
+
+We will store all PocketBase data on a separate 10GB `pd-balanced` persistent disk named `pod-data`, created in `us-central1-a` with `auto-delete=no`. The `deploy.sh` script either creates a new disk or attaches an existing one when provisioning the VM.
+
+The startup script formats the disk as ext4 on first use (idempotently — it checks `blkid` before formatting), mounts it at `/mnt/pod-data`, and bind-mounts it into the PocketBase container at `/data`. The `pb_data` directory lives at `/mnt/pod-data/pb_data` on the host.
+
+A daily snapshot policy (`pod-data-daily-backup`) runs at 03:00 UTC with 7-day retention, configured via `gcloud compute resource-policies`.
+
+## Consequences
+
+- The VM can be deleted and recreated without any data loss. The persistent disk and its contents survive independently.
+- Daily snapshots provide point-in-time recovery for up to 7 days. This protects against accidental data corruption or deletion.
+- The disk is a first-class GCP resource with its own lifecycle, visible in the GCP console and manageable via `gcloud` commands.
+- First-time disk formatting is an idempotent operation in the startup script, but it must be handled carefully — an accidental format of a disk with existing data would be destructive.
+- Snapshot retention at 7 days means incidents older than a week cannot be recovered from snapshots alone.
+- The 10GB disk size is generous for a community site using SQLite. PocketBase is unlikely to approach this limit in the near term.
+- The disk must be in the same zone (`us-central1-a`) as the VM, which limits geographic flexibility.

--- a/doc/adr/0008-container-registry-google-artifact-registry.md
+++ b/doc/adr/0008-container-registry-google-artifact-registry.md
@@ -1,0 +1,24 @@
+# ADR 0008: Container Registry — Google Artifact Registry
+
+**Status**: Accepted
+
+**Date**: 2026-02-28
+
+## Context
+
+The PocketBase container image needs to be stored in a registry that the GCE VM can pull from. The team already uses GCP for the backend VM (see [ADR 0005](0005-backend-hosting-on-gce-e2-micro.md)). GCE VMs can authenticate to Google Artifact Registry using their service account, which avoids managing separate registry credentials.
+
+## Decision
+
+We will use Google Artifact Registry at `us-central1-docker.pkg.dev/cscsdotdev/website` as the container image registry. Images are tagged as `backend:latest` and pushed using `make build-push` from the `backend/` directory.
+
+Multi-architecture images (linux/amd64 and linux/arm64) are built using `podman build --platform` to support both the amd64 GCE production VM and arm64 developer machines (Apple Silicon). The VM authenticates to the registry at startup using `gcloud auth print-access-token` piped to `podman login`.
+
+## Consequences
+
+- Authentication is handled by GCP IAM — no separate registry credentials to manage, rotate, or store.
+- The registry is co-located in the same region (`us-central1`) as the VM, minimizing image pull latency.
+- Multi-arch builds allow the same image to run on Apple Silicon developer machines and the amd64 GCE VM without platform-specific tags.
+- The `latest` tag means the running container is not pinned to a specific version. A bad image push could affect production on the next VM start or container restart.
+- Registry access requires an authenticated `gcloud` session on the developer's machine to push images.
+- Artifact Registry storage costs are billed to the GCP project `cscsdotdev`, though they are negligible for a single image.

--- a/doc/adr/0009-ci-cd-github-actions-and-netlify.md
+++ b/doc/adr/0009-ci-cd-github-actions-and-netlify.md
@@ -1,0 +1,29 @@
+# ADR 0009: CI/CD — GitHub Actions and Netlify
+
+**Status**: Accepted
+
+**Date**: 2026-02-28
+
+## Context
+
+Code changes must be validated before they go live. The project uses GitHub as the source of truth. Two concerns exist: validation (does the code pass lint, format, tests, and build?) and deployment (how does validated code reach production?).
+
+These are handled by two separate systems. GitHub Actions provides a configurable CI pipeline. Netlify provides automatic deployment with its native GitHub integration. The question is whether to unify them or keep them separate.
+
+## Decision
+
+We will use GitHub Actions for the CI validation pipeline and Netlify's native GitHub integration for deployment. These two systems operate independently.
+
+The GitHub Actions workflow (`.github/workflows/ci.yml`) runs on every push to `main` and on every pull request targeting `main`. It executes six steps: lint (ESLint), format check (Prettier `--check`), tests (Vitest), Astro build, and Storybook build.
+
+Netlify watches the same repository and deploys independently when it detects a push to `main`, using its own auto-detected Astro build settings. Netlify is not triggered by or dependent on the GitHub Actions workflow.
+
+## Consequences
+
+- CI catches lint errors, formatting issues, test failures, and build errors before or after merge, depending on whether branch protection rules require status checks.
+- Netlify deployment is fast and requires no deploy step in the CI workflow — it is fully managed.
+- Pull request deploy previews from Netlify are available for visual review.
+- CI and deployment are decoupled. A push to `main` can fail CI but still deploy to Netlify, since Netlify does not wait for GitHub Actions to pass. This is a known gap.
+- There is no staging environment. Every merge to `main` deploys directly to production on Netlify.
+- The Astro build runs twice on every push to `main` — once in GitHub Actions (for validation) and once in Netlify (for deployment). This is redundant but acceptable at the current scale.
+- CI uses Node.js 20 on `ubuntu-latest`. The build artifact produced by CI is discarded — Netlify builds its own artifact.

--- a/doc/adr/0010-backend-deployment-via-manual-script.md
+++ b/doc/adr/0010-backend-deployment-via-manual-script.md
@@ -1,0 +1,29 @@
+# ADR 0010: Backend Deployment via Manual Script
+
+**Status**: Accepted
+
+**Date**: 2026-02-28
+
+## Context
+
+The backend (GCE VM running PocketBase) does not have an automated deployment pipeline equivalent to the frontend's Netlify integration. Backend infrastructure changes infrequently — the VM is provisioned once and runs until it is intentionally replaced. Automating GCE provisioning in CI would require storing GCP service account credentials in GitHub Secrets and building a more complex workflow.
+
+The `MIGRATIONS.md` documentation describes a pipeline flow of `Git → CI/CD Build → GCE VM → Container Restart → Migrations Apply`, but this automated pipeline does not exist yet.
+
+## Decision
+
+We will manage backend infrastructure and deployment manually using `backend/deploy.sh` and `backend/Makefile`. The deployment workflow has two parts:
+
+**Infrastructure lifecycle**: `deploy.sh up` provisions the GCE VM with all dependent resources (firewall rules, static IP, persistent disk, snapshot policy). `deploy.sh down` deletes the VM while preserving the data disk and static IP. The script is idempotent — it checks for existing resources before creating them.
+
+**Application updates**: New container images are built and pushed using `make build-push` from the `backend/` directory. Updating a running deployment requires SSHing into the VM, pulling the new image, and restarting the systemd service.
+
+## Consequences
+
+- No GCP credentials need to be stored in CI. The deployment process requires only a developer with `gcloud` access and SSH key authorization.
+- The deployment process is explicit and auditable — every action is a deliberate human decision.
+- The `deploy.sh` script is idempotent for resource creation, making it safe to run `up` multiple times.
+- There is no automated deployment pipeline for backend changes. A developer must manually build, push, and restart for every update.
+- The process for updating a live container (SSH, pull, restart) is not formally documented in the deploy script — it only handles VM creation and deletion.
+- There is no automated rollback. If a bad image is pushed, recovery requires manually pulling a previous image or restoring from a disk snapshot.
+- This is appropriate for a low-change-frequency service at community scale. The operational simplicity outweighs the automation gap for now.

--- a/doc/adr/0011-local-development-with-podman-compose.md
+++ b/doc/adr/0011-local-development-with-podman-compose.md
@@ -1,0 +1,31 @@
+# ADR 0011: Local Development with Podman Compose
+
+**Status**: Accepted
+
+**Date**: 2026-02-28
+
+## Context
+
+Developers need to run both the Astro frontend and PocketBase backend locally. The setup should be consistent across developer machines, not require global tool installations beyond Podman, and support hot-reloading of frontend code changes during development.
+
+Docker Compose is the more widely known tool, but the project uses Podman for production containers (see [ADR 0006](0006-container-runtime-podman-with-quadlet.md)). Using the same container runtime in development and production reduces environment inconsistencies.
+
+## Decision
+
+We will use `podman-compose.yaml` at the project root to define the local development environment with two services:
+
+**pocketbase**: Built from `backend/Containerfile`, running on port 8080 with `./backend/pb_data` bind-mounted for persistent local database state. The admin dashboard is accessible at `http://localhost:8080/_/`.
+
+**cscs**: Built from the root `Containerfile` (a Node.js dev server image), running on port 4321 with the entire project directory volume-mounted for hot-reloading. The environment variable `PUBLIC_POCKETBASE_URL` is set to `http://localhost:8080` for browser-side API access.
+
+The full stack starts with `podman-compose up --build` and stops with `podman-compose down`.
+
+## Consequences
+
+- A single command starts the complete development stack with both frontend and backend.
+- Hot-reloading works because the source directory is mounted into the frontend container — file changes on the host are reflected immediately.
+- The `pb_data` directory is bind-mounted so local database state (users, events, RSVPs) persists across container restarts.
+- Podman and Podman Compose must be installed on the developer's machine. This is documented in `README.md`.
+- The root `Containerfile` is a development-only image (Node.js dev server); it is not used in production.
+- The frontend service uses `node_modules` from inside the container image, which can cause confusion if the host also has a `node_modules` directory from running `npm install` locally.
+- The compose setup is explicitly for development. Production uses a completely different deployment path (GCE VM with Quadlet — see [ADR 0006](0006-container-runtime-podman-with-quadlet.md)).

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -1,0 +1,19 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the cscs.dev project, following [Michael Nygard's format](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions). Each ADR is a short document that captures a significant architectural decision along with its context and consequences.
+
+To propose a new ADR, copy [template.md](template.md) and fill in the sections.
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-record-architecture-decisions.md) | Record Architecture Decisions | Accepted |
+| [0002](0002-static-site-generation-with-astro.md) | Static Site Generation with Astro | Accepted |
+| [0003](0003-frontend-hosting-on-netlify.md) | Frontend Hosting on Netlify | Accepted |
+| [0004](0004-pocketbase-as-backend.md) | PocketBase as Backend | Accepted |
+| [0005](0005-backend-hosting-on-gce-e2-micro.md) | Backend Hosting on GCE e2-micro | Accepted |
+| [0006](0006-container-runtime-podman-with-quadlet.md) | Container Runtime — Podman with Quadlet | Accepted |
+| [0007](0007-persistent-data-on-separate-gce-disk.md) | Persistent Data on Separate GCE Disk | Accepted |
+| [0008](0008-container-registry-google-artifact-registry.md) | Container Registry — Google Artifact Registry | Accepted |
+| [0009](0009-ci-cd-github-actions-and-netlify.md) | CI/CD — GitHub Actions and Netlify | Accepted |
+| [0010](0010-backend-deployment-via-manual-script.md) | Backend Deployment via Manual Script | Accepted |
+| [0011](0011-local-development-with-podman-compose.md) | Local Development with Podman Compose | Accepted |

--- a/doc/adr/template.md
+++ b/doc/adr/template.md
@@ -1,0 +1,23 @@
+# ADR NNNN: Title in Short Noun Phrase
+
+**Status**: proposed | accepted | deprecated | superseded by [ADR NNNN](NNNN-title.md)
+
+**Date**: YYYY-MM-DD
+
+## Context
+
+Describe the forces at play, including technological, political, social, and project-local factors. Present the situation and constraints using neutral, factual language. Do not state the decision here.
+
+## Decision
+
+We will [active-voice statement of the decision made].
+
+Expand with additional sentences as needed. Use full sentences and active voice throughout.
+
+## Consequences
+
+List all consequences — positive, negative, and neutral.
+
+- Positive consequence
+- Negative consequence
+- Neutral consequence


### PR DESCRIPTION
## Summary

- Introduces Architecture Decision Records (ADRs) following Michael Nygard's format (`doc/adr/`)
- Documents 11 architectural decisions covering the full deployment and production stack
- Includes a reusable template and index for future ADRs

### ADRs included

| # | Decision |
|---|----------|
| 0001 | Record Architecture Decisions (meta-ADR) |
| 0002 | Static Site Generation with Astro |
| 0003 | Frontend Hosting on Netlify |
| 0004 | PocketBase as Backend |
| 0005 | Backend Hosting on GCE e2-micro |
| 0006 | Container Runtime — Podman with Quadlet |
| 0007 | Persistent Data on Separate GCE Disk |
| 0008 | Container Registry — Google Artifact Registry |
| 0009 | CI/CD — GitHub Actions and Netlify |
| 0010 | Backend Deployment via Manual Script |
| 0011 | Local Development with Podman Compose |

## Test plan

- [x] `npm run build` passes — new `doc/` directory does not affect Astro build
- [ ] Review ADR content for accuracy against deploy scripts and config files
- [ ] Verify cross-references between ADRs resolve correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)