### PR TITLE
feat: add /work-on-issue skill for full issue lifecycle

### DIFF
--- a/.claude/skills/work-on-issue/SKILL.md
+++ b/.claude/skills/work-on-issue/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: work-on-issue
+description: Full lifecycle workflow for a GitHub issue — fetch context, create worktree, investigate, plan, implement, verify, commit, and open a PR.
+disable-model-invocation: true
+argument-hint: "[issue-number]"
+---
+
+# Work on Issue
+
+Complete workflow to take a GitHub issue from triage to pull request.
+
+**Repository**: `The-Read-Onlys/cscs.dev`
+**Issue number**: `$ARGUMENTS` (required — abort with a clear message if empty)
+
+---
+
+## Step 1 — Fetch Issue Context
+
+Gather all issue details in parallel:
+
+- `mcp__github__issue_read` with method `get`, owner `The-Read-Onlys`, repo `cscs.dev`, issue_number `$ARGUMENTS`
+- `mcp__github__issue_read` with method `get_comments`, same owner/repo/issue_number
+- `mcp__github__issue_read` with method `get_labels`, same owner/repo/issue_number
+
+Summarize the issue to the user: title, description, labels, and any discussion highlights.
+
+If the issue is not found (404), stop and tell the user.
+
+---
+
+## Step 2 — Create Worktree
+
+Derive a short slug from the issue title (lowercase, hyphens, max 40 chars).
+
+Call `EnterWorktree` with name `issue-$ARGUMENTS-{slug}`.
+
+If the worktree already exists, ask the user whether to reuse it or pick a new name.
+
+---
+
+## Step 3 — Investigate
+
+Read files mentioned in the issue body or comments. Search the codebase for related patterns using Grep and Glob. Build enough context to design a solution. Use the Explore agent for deeper investigation if needed.
+
+---
+
+## Step 4 — Plan
+
+Call `EnterPlanMode` and write a clear implementation plan. This is a **hard gate** — do not proceed until the user approves the plan via `ExitPlanMode`.
+
+The plan should reference specific files, functions, and line numbers discovered in Step 3.
+
+---
+
+## Step 5 — Implement
+
+Make changes following CLAUDE.md conventions:
+
+- Use Catalyst UI components where applicable
+- Support dark mode (`dark:` Tailwind variants)
+- Use TypeScript strict mode types
+- Follow the project's naming and import conventions
+- Keep changes minimal and focused on the issue
+
+---
+
+## Step 6 — Verify
+
+Run these commands **sequentially** (each must pass before the next):
+
+1. `npm run build` — must exit 0
+2. `npm run lint` — must exit 0
+3. `npm run format` — applies Prettier formatting
+
+If build or lint fails, fix the errors and re-run from the failing step. Do not proceed to commit with broken build/lint.
+
+---
+
+## Step 7 — Commit
+
+1. Run `git status` and `git diff` to review all changes
+2. Stage **specific files** (never `git add -A`)
+3. Create a commit with a conventional commit message:
+
+```
+<type>: <short description>
+
+<body explaining what and why>
+
+Closes #$ARGUMENTS
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+Use the appropriate type: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`.
+
+---
+
+## Step 8 — Create PR
+
+1. Push the branch: `git push -u origin HEAD`
+2. Create the PR using `mcp__github__create_pull_request`:
+   - owner: `The-Read-Onlys`
+   - repo: `cscs.dev`
+   - title: Short description (under 70 chars)
+   - head: current branch name
+   - base: `main`
+   - body: Use this template:
+
+```markdown
+## Summary
+- <1-3 bullet points describing the changes>
+
+Closes #$ARGUMENTS
+
+## Test plan
+- [ ] `npm run build` passes
+- [ ] `npm run lint` passes
+- [ ] Manual verification of <specific things to check>
+
+Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+3. Print the PR URL to the user.
+
+---
+
+## Step 9 — Cleanup
+
+Ask the user: "Should I close issue #$ARGUMENTS now, or let the PR merge close it automatically?"
+
+- If close now → `mcp__github__issue_write` with method `update`, state `closed`, state_reason `completed`
+- If let PR close it → confirm the `Closes #$ARGUMENTS` reference is in the PR body (it is from Step 8)
+
+---
+
+## Error Handling
+
+| Scenario | Action |
+|---|---|
+| Issue not found | Stop immediately, tell the user |
+| Worktree name conflict | Ask user for alternative name |
+| Build fails | Fix errors, re-run build |
+| Lint fails | Fix errors, re-run lint |
+| Push rejected | Pull with rebase, resolve conflicts, push again |
+| PR already exists for branch | Show existing PR URL, ask user how to proceed |


### PR DESCRIPTION
## Summary
- Adds a new `/work-on-issue [issue-number]` Claude Code skill that codifies the full worktree-based workflow into a single command
- Covers 9 steps: fetch issue → create worktree → investigate → plan (with user approval gate) → implement → verify → commit → PR → cleanup
- User-triggered only (`disable-model-invocation: true`) — Claude will never auto-invoke this

## Test plan
- [ ] `/work-on-issue` appears in `/` autocomplete with description and `[issue-number]` hint
- [ ] `/work-on-issue 25` on a real issue fetches context, creates worktree, and begins investigation
- [ ] Skill does NOT appear in auto-invocation suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)