### PR TITLE
Fix optional Storybook ESLint plugin loading

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,23 @@
 // For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
-import storybook from "eslint-plugin-storybook";
-
 import eslintPluginAstro from "eslint-plugin-astro";
 import tseslint from "typescript-eslint";
+
+async function loadStorybookConfig() {
+  try {
+    const storybook = await import("eslint-plugin-storybook");
+    return storybook.default.configs["flat/recommended"];
+  } catch (error) {
+    if (
+      error?.code === "ERR_MODULE_NOT_FOUND" &&
+      error?.message?.includes("eslint-plugin-storybook")
+    ) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+const storybookConfig = await loadStorybookConfig();
 
 export default [
   {
@@ -24,5 +39,5 @@ export default [
       "@typescript-eslint/no-explicit-any": "off",
     },
   },
-  ...storybook.configs["flat/recommended"],
+  ...storybookConfig,
 ];


### PR DESCRIPTION
## Summary
- Load `eslint-plugin-storybook` with a guarded dynamic import.
- Keep Storybook's recommended flat config active whenever the plugin is installed.
- Skip only the Storybook ESLint rules when the plugin package is missing, so `eslint .` can still lint the rest of the project.

Fixes #47

## Validation
- `npm install --ignore-scripts --no-audit --no-fund`
- `npm run lint`
- Temporarily moved `node_modules/eslint-plugin-storybook` out of `node_modules`, then ran `npm run lint` again to verify ESLint no longer crashes when the plugin is absent.
- Restored the plugin directory and ran `npm run build`.
- `git diff --check -- eslint.config.js`